### PR TITLE
Add BASEPATH env var to enable use of --base-path option

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -47,7 +47,7 @@ opt_param_usage_include_env: true
 opt_param_env_vars:
   - { env_var: "PASSWORD", env_value: "password", desc: "Optional web gui password, if not provided, there will be no auth."}
   - { env_var: "SUDO_PASSWORD", env_value: "password", desc: "If this optional variable is set, user will have sudo access in the code-server terminal with the specified password."}
-  - { env_var: "BASEPATH", env_value: "code", desc: "If this optional variable is set, code-server will be served from http://<your-ip>:8443/code. See code-server --base-path option"}
+  - { env_var: "BASEPATH", env_value: "", desc: "Optional base url setting (ie. if set to `code`, code-server will be served from `http://<your-ip>:8443/code`)."}
 
 optional_block_1: false
 optional_block_1_items: ""

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -47,6 +47,7 @@ opt_param_usage_include_env: true
 opt_param_env_vars:
   - { env_var: "PASSWORD", env_value: "password", desc: "Optional web gui password, if not provided, there will be no auth."}
   - { env_var: "SUDO_PASSWORD", env_value: "password", desc: "If this optional variable is set, user will have sudo access in the code-server terminal with the specified password."}
+  - { env_var: "BASEPATH", env_value: "code", desc: "If this optional variable is set, code-server will be served from http://<your-ip>:8443/code. See code-server --base-path option"}
 
 optional_block_1: false
 optional_block_1_items: ""
@@ -65,6 +66,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "14.02.20:", desc: "Add support for --base-path option."}
   - { date: "17.01.20:", desc: "Fix artifact url retrieval from github." }
   - { date: "24.10.19:", desc: "Upgrade to v2 builds." }
   - { date: "28.09.19:", desc: "Update project logo." }

--- a/root/etc/services.d/code-server/run
+++ b/root/etc/services.d/code-server/run
@@ -22,5 +22,5 @@ exec \
 			--disable-telemetry \
 			--disable-updates \
 			--auth "${AUTH}" \
-			"${BASEPATH}" \
+			${BASEPATH} \
 			/config/workspace

--- a/root/etc/services.d/code-server/run
+++ b/root/etc/services.d/code-server/run
@@ -7,6 +7,12 @@ else
   echo "starting with no password"
 fi
 
+if [ -n "${BASEPATH}" ]; then
+  BASEPATH="--base-path ${BASEPATH}"
+else
+  BASEPATH=""
+fi
+
 exec \
 	s6-setuidgid abc \
 		/usr/bin/code-server \
@@ -16,4 +22,5 @@ exec \
 			--disable-telemetry \
 			--disable-updates \
 			--auth "${AUTH}" \
+			"${BASEPATH}" \
 			/config/workspace


### PR DESCRIPTION
## Description:
<!--- Describe your changes in detail -->
Add support for BASEPATH environment variable to enable use of code-server `--base-path` option

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
When reverse proxied, allows code-server to be served from any path, not just the root of the domain/ip, eg: `http://<your-ip>:8443/code`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* built image with changes using instructions at end of README.md
* created and launched image with:
```
docker run -it \
  --name=code-server \
  -e PUID=1000 \
  -e PGID=1000 \
  -e TZ=Europe/London \
  -e PASSWORD=password \
  -e SUDO_PASSWORD=password  \
  -e BASEPATH=coder \
  -p 8443:8443 \
  -v /path/to/appdata/config:/config \
  --restart unless-stopped \
  linuxserver/code-server:latest
```
* configured nginx reverse proxy to serve code-server from `http://<your-ip>:8443/code`
```
	location /code {
		rewrite /code /code/ permanent;
	}

	location /code/ {
		proxy_pass http://localhost:8443/;
		proxy_set_header Host $host;
		proxy_set_header Upgrade $http_upgrade;
		proxy_set_header Connection upgrade;
		proxy_set_header Accept-Encoding gzip;
		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
		proxy_set_header X-Forwarded-Proto $scheme;
		proxy_set_header X-Real-IP $remote_addr;
	}
```
* navigate to `http://<your-ip>:8443/code`
* code-server redirects to `http://<your-ip>:8443/code/login`
* enter login credentials
* code-server redirects back to `http://<your-ip>:8443/code`
* UI is displayed and functions as expected

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
--base-path option: https://github.com/cdr/code-server/blob/c8fc54bfb1ba0fae592dee33a5f68843d9b41a4a/src/node/cli.ts#L59