### PR TITLE
Added option to enable SSL, provide certificate/key and set server port.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,9 @@ LABEL maintainer="aptalca"
 ENV HOME="/config"
 
 RUN \
+ DEBIAN_FRONTEND="noninteractive" \
  apt-get update && \
- apt-get install -y \
+ DEBIAN_FRONTEND="noninteractive" apt-get install -y \
 	git \
 	jq \
 	nano \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -35,6 +35,7 @@ param_container_name: "{{ project_name }}"
 param_usage_include_vols: true
 param_volumes:
   - { vol_path: "/config", vol_host_path: "/path/to/appdata/config", desc: "Contains all relevant configuration files." }
+  - { vol_path: "/certificates", vol_host_path: "/path/to/appdata/certificates", desc: "Contains the certificate as well as the key file for SSL encryption" }
 param_usage_include_ports: true
 param_ports:
   - { external_port: "8443", internal_port: "8443", port_desc: "web gui" }
@@ -45,7 +46,11 @@ param_env_vars:
 # optional container parameters
 opt_param_usage_include_env: true
 opt_param_env_vars:
+  - { env_var: "HTTPS_CERT", env_value: "/certificates/cert_name.crt", "Full path to certificate file that should be used. PEM encoded." }
+  - { env_var: "HTTPS_KEY", env_value: "/certificates/key_name.key", "Full path to the key file that is to be used. PEM encoded, unencrypted." }
   - { env_var: "PASSWORD", env_value: "password", desc: "Optional web gui password, if not provided, there will be no auth."}
+  - { env_var: "SERVER_PORT", env_value: "8443", desc: "Optional port of the web server that should be used. Cannot be less than 1024."}
+  - { env_var: "SSL_ENABLED", env_value: "true", desc: "Enable SSL encryption for the connection. If no cert/key is provided, it is auto generated."}
   - { env_var: "SUDO_PASSWORD", env_value: "password", desc: "If this optional variable is set, user will have sudo access in the code-server terminal with the specified password."}
 
 optional_block_1: false
@@ -65,6 +70,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "09.03.20:", desc: "Added SSL support and option to set server port." }
   - { date: "17.01.20:", desc: "Fix artifact url retrieval from github." }
   - { date: "24.10.19:", desc: "Upgrade to v2 builds." }
   - { date: "28.09.19:", desc: "Update project logo." }

--- a/root/etc/services.d/code-server/run
+++ b/root/etc/services.d/code-server/run
@@ -1,5 +1,25 @@
 #!/usr/bin/with-contenv bash
 
+CODE_SERVER_PORT="${SERVER_PORT:-8443}"
+CODE_SERVER_SSL="${SSL_ENABLED:-false}"
+
+SSL_CERT_COMMAND=
+SSL_CERT_FILE=
+SSL_KEY_COMMAND=
+SSL_KEY_FILE=
+
+if [ "${CODE_SERVER_SSL}x" != "falsex" ]; then
+	SSL_CERT_COMMAND="--cert"
+  
+  if [ -f "${HTTPS_CERT}" ] && [ -f "${HTTPS_KEY}" ]; then
+
+	SSL_CERT_COMMAND="--cert"
+	SSL_CERT_FILE="${HTTPS_CERT}"
+	SSL_KEY_COMMAND="--cert-key"
+	SSL_KEY_FILE="${HTTPS_KEY}"
+  fi
+fi
+
 if [ -n "${PASSWORD}" ]; then
   AUTH="password"
 else
@@ -10,7 +30,9 @@ fi
 exec \
 	s6-setuidgid abc \
 		/usr/bin/code-server \
-			--port 8443 \
+			${SSL_CERT_COMMAND} ${SSL_CERT_FILE} \
+			${SSL_KEY_COMMAND} ${SSL_KEY_FILE} \
+			--port "${CODE_SERVER_PORT}" \
 			--user-data-dir /config/data \
 			--extensions-dir /config/extensions \
 			--disable-telemetry \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  --> 
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

We welcome all PR’s though this doesn’t guarantee it will be accepted.

## Description:
Added option to enable SSL via environment variable "SSL_ENABLED". If it is set to anything else than "false" SSL will be enabled and the code-server will auto generate the certificate and the key (It's a feature of code-server.).

Certificate and key file can also be provided via the environment variables "HTTPS_CERT" and "HTTPS_KEY". They should contain a full path to the corresponding file inside the container. If both files exist, they will be handed to the code-server to use them. There are no special checks done on the content of the files. If they exist, they're used. Garbage in, garbage out.

Another option is to set the server's port via the environment variable "SERVER_PORT". Again: No checks are done. The port cannot be < 1024 because the server is not running as root and I didn't want to change that.

I added a bit of a description to the readme-vars.yml file, but was unsure where to put the information about the fact that code-server can auto generate the certificates on its own. I also added the volume for the certificates to the readme-vars.yml file as well as an updated log.  The certificate/key could probably be put into the config volume, but wasn't sure. If that's a possibility, let me know and we can change the description. 

Last but not least, I changed the Dockerfile to contain the environment variable "DEBIAN_ENVIRONMENT" with the value "noninteractive" to avoid the error messages during the setup of the container.

## Benefits of this PR and context:
Advanced features, more use cases... 

## How Has This Been Tested?
Setup a docker-compose.yaml file and then tested by providing every variable and checking the action/reaction of the container after recreating it. Not really much to test on a few lines of shell script. It's working. If one of the files, cert/key, is missing, the certificate will be auto generated and if the port is < 1024 the server will put errors into the log file. 

## Source / References:
Nothing to put here.

