### PR TITLE
Add support for serving via HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,11 +124,13 @@ Container images are configured using parameters passed at runtime (such as thos
 | `-e TZ=Europe/London` | Specify a timezone to use EG Europe/London |
 | `-e PASSWORD=password` | Optional web gui password, if not provided, there will be no auth. |
 | `-e SUDO_PASSWORD=password` | If this optional variable is set, user will have sudo access in the code-server terminal with the specified password. |
+| `-e SSL_CERT=/ssl/cert_file.crt` | If this optional variable is provided in conjunction with a key file the code-server run be served via HTTPS. |
+| `-e SSL_KEY=/ssl/key_file.key` | If this optional variable is provided in conjunction with a cert file the code-server run be served via HTTPS. |
 | `-v /config` | Contains all relevant configuration files. |
 
 ## Environment variables from files (Docker secrets)
 
-You can set any environment variable from a file by using a special prepend `FILE__`. 
+You can set any environment variable from a file by using a special prepend `FILE__`.
 
 As an example:
 
@@ -155,9 +157,9 @@ In this instance `PUID=1000` and `PGID=1000`, to find yours use `id user` as bel
 &nbsp;
 ## Application Setup
 
-Access the webui at `http://<your-ip>:8443`.  
-For github integration, drop your ssh key in to `/config/.ssh`.  
-Then open a terminal from the top menu and set your github username and email via the following commands  
+Access the webui at `http://<your-ip>:8443`.
+For github integration, drop your ssh key in to `/config/.ssh`.
+Then open a terminal from the top menu and set your github username and email via the following commands
 ```
 git config --global user.name "username"
 git config --global user.email "email address"

--- a/root/etc/services.d/code-server/run
+++ b/root/etc/services.d/code-server/run
@@ -16,4 +16,6 @@ exec \
 			--disable-telemetry \
 			--disable-updates \
 			--auth "${AUTH}" \
+			--cert "${CERT}" \
+			--cert-key "${CERT_KEY}" \
 			/config/workspace

--- a/root/etc/services.d/code-server/run
+++ b/root/etc/services.d/code-server/run
@@ -16,4 +16,12 @@ fi
 
 exec \
 	s6-setuidgid abc \
-		/usr/bin/code-server --port 8443 --user-data-dir /config/data --extensions-dir /config/extensions --disable-telemetry --disable-updates --auth "${AUTH}" "${SSL_CONFIG}" /config/workspace
+		/usr/bin/code-server \
+			--port 8443 \
+			--user-data-dir /config/data \
+			--extensions-dir /config/extensions \
+			--disable-telemetry \
+			--disable-updates \
+			--auth "${AUTH}" \
+			"${SSL_CONFIG}" \
+			/config/workspace

--- a/root/etc/services.d/code-server/run
+++ b/root/etc/services.d/code-server/run
@@ -7,6 +7,12 @@ else
   echo "starting with no password"
 fi
 
+if [ -n "${CERT_KEY}" ]; then
+	KEY="--cert-key ${CERT_KEY}"
+else
+	KEY=""
+fi
+
 exec \
 	s6-setuidgid abc \
 		/usr/bin/code-server \
@@ -17,5 +23,5 @@ exec \
 			--disable-updates \
 			--auth "${AUTH}" \
 			--cert "${CERT}" \
-			--cert-key "${CERT_KEY}" \
+			"${KEY}" \
 			/config/workspace

--- a/root/etc/services.d/code-server/run
+++ b/root/etc/services.d/code-server/run
@@ -8,7 +8,7 @@ else
 fi
 
 if [ -n "${SSL_KEY}" ] && [ -n "${SSL_CERT}" ]; then
-	SSL_CONFIG="--cert \'${SSL_CERT}\' --cert-key \'${SSL_KEY}\'"
+	SSL_CONFIG="--cert ${SSL_CERT} --cert-key ${SSL_KEY}"
 else
 	echo "Running insecurely on HTTP."
 	SSL_CONFIG=""

--- a/root/etc/services.d/code-server/run
+++ b/root/etc/services.d/code-server/run
@@ -7,10 +7,11 @@ else
   echo "starting with no password"
 fi
 
-if [ -n "${CERT_KEY}" ]; then
-	KEY="--cert-key ${CERT_KEY}"
+if [ -n "${SSL_KEY}" ] && [ -n "${SSL_CERT}" ]; then
+	SSL_CONFIG="--cert ${SSL_CERT} --cert-key ${SSL_KEY}"
 else
-	KEY=""
+	echo "Running insecurely on HTTP."
+	SSL_CONFIG=""
 fi
 
 exec \
@@ -22,6 +23,5 @@ exec \
 			--disable-telemetry \
 			--disable-updates \
 			--auth "${AUTH}" \
-			--cert "${CERT}" \
-			"${KEY}" \
+			"${SSL_CONFIG}" \
 			/config/workspace

--- a/root/etc/services.d/code-server/run
+++ b/root/etc/services.d/code-server/run
@@ -7,6 +7,12 @@ else
   echo "starting with no password"
 fi
 
+if [ -n "${WORKSPACE_PATH}" ]; then
+	WORKSPACE="/config/workspace"
+else
+	WORKSPACE="${WORKSPACE_PATH}"
+fi
+
 exec \
 	s6-setuidgid abc \
 		/usr/bin/code-server \
@@ -18,4 +24,4 @@ exec \
 			--auth "${AUTH}" \
 			--cert "${CERT}" \
 			--cert-key "${CERT_KEY}" \
-			/config/workspace
+			"${WORKSPACE}"

--- a/root/etc/services.d/code-server/run
+++ b/root/etc/services.d/code-server/run
@@ -8,10 +8,12 @@ else
 fi
 
 if [ -n "${SSL_KEY}" ] && [ -n "${SSL_CERT}" ]; then
-	SSL_CONFIG="--cert ${SSL_CERT} --cert-key ${SSL_KEY}"
+	SSL_CERT="--cert ${SSL_CERT}"
+	SSL_KEY="--cert-key ${SSL_KEY}"
 else
 	echo "Running insecurely on HTTP."
-	SSL_CONFIG=""
+	SSL_CERT=""
+	SSL_KEY=""
 fi
 
 exec \
@@ -23,5 +25,6 @@ exec \
 			--disable-telemetry \
 			--disable-updates \
 			--auth "${AUTH}" \
-			"${SSL_CONFIG}" \
+			"${SSL_CERT}" \
+			"${SSL_KEY}" \
 			/config/workspace

--- a/root/etc/services.d/code-server/run
+++ b/root/etc/services.d/code-server/run
@@ -7,12 +7,6 @@ else
   echo "starting with no password"
 fi
 
-if [ -n "${WORKSPACE_PATH}" ]; then
-	WORKSPACE="/config/workspace"
-else
-	WORKSPACE="${WORKSPACE_PATH}"
-fi
-
 exec \
 	s6-setuidgid abc \
 		/usr/bin/code-server \
@@ -24,4 +18,4 @@ exec \
 			--auth "${AUTH}" \
 			--cert "${CERT}" \
 			--cert-key "${CERT_KEY}" \
-			"${WORKSPACE}"
+			/config/workspace

--- a/root/etc/services.d/code-server/run
+++ b/root/etc/services.d/code-server/run
@@ -8,7 +8,7 @@ else
 fi
 
 if [ -n "${SSL_KEY}" ] && [ -n "${SSL_CERT}" ]; then
-	SSL_CONFIG="--cert \"${SSL_CERT}\" --cert-key \"${SSL_KEY}\""
+	SSL_CONFIG="--cert \'${SSL_CERT}\' --cert-key \'${SSL_KEY}\'"
 else
 	echo "Running insecurely on HTTP."
 	SSL_CONFIG=""

--- a/root/etc/services.d/code-server/run
+++ b/root/etc/services.d/code-server/run
@@ -8,7 +8,7 @@ else
 fi
 
 if [ -n "${SSL_KEY}" ] && [ -n "${SSL_CERT}" ]; then
-	SSL_CONFIG=" --cert ${SSL_CERT} --cert-key ${SSL_KEY}"
+	SSL_CONFIG="--cert ${SSL_CERT} --cert-key ${SSL_KEY}"
 else
 	echo "Running insecurely on HTTP."
 	SSL_CONFIG=""

--- a/root/etc/services.d/code-server/run
+++ b/root/etc/services.d/code-server/run
@@ -8,23 +8,12 @@ else
 fi
 
 if [ -n "${SSL_KEY}" ] && [ -n "${SSL_CERT}" ]; then
-	SSL_CERT="--cert ${SSL_CERT}"
-	SSL_KEY="--cert-key ${SSL_KEY}"
+	SSL_CONFIG=" --cert ${SSL_CERT} --cert-key ${SSL_KEY}"
 else
 	echo "Running insecurely on HTTP."
-	SSL_CERT=""
-	SSL_KEY=""
+	SSL_CONFIG=""
 fi
 
 exec \
 	s6-setuidgid abc \
-		/usr/bin/code-server \
-			--port 8443 \
-			--user-data-dir /config/data \
-			--extensions-dir /config/extensions \
-			--disable-telemetry \
-			--disable-updates \
-			--auth "${AUTH}" \
-			"${SSL_CERT}" \
-			"${SSL_KEY}" \
-			/config/workspace
+		/usr/bin/code-server --port 8443 --user-data-dir /config/data --extensions-dir /config/extensions --disable-telemetry --disable-updates --auth "${AUTH}" "${SSL_CONFIG}" /config/workspace

--- a/root/etc/services.d/code-server/run
+++ b/root/etc/services.d/code-server/run
@@ -8,7 +8,7 @@ else
 fi
 
 if [ -n "${SSL_KEY}" ] && [ -n "${SSL_CERT}" ]; then
-	SSL_CONFIG="--cert ${SSL_CERT} --cert-key ${SSL_KEY}"
+	SSL_CONFIG="--cert \"${SSL_CERT}\" --cert-key \"${SSL_KEY}\""
 else
 	echo "Running insecurely on HTTP."
 	SSL_CONFIG=""


### PR DESCRIPTION
Support serving the code-server via HTTPS when passing in `SSL_CERT` and `SSL_KEY`, otherwise maintain current behavior.

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

## Description:
Modify the run script to pass values from environment variables `SSL_CERT` and `SSL_KEY` to options `--cert` and `--cert-key` respectively, as per the man page:
```
  --cert                         Path to certificate. If the path is omitted,
                                 both this and --cert-key will be generated.
  --cert-key                     Path to the certificate's key if one was
                                 provided.
```

If both environment variables are not set, code-server will run HTTP, as is the current behavior.

## Benefits of this PR and context:
Support serving via HTTPS.

## How Has This Been Tested?
Run with both variables defined, code-server runs HTTPS
Run without both variables defined, code server runs HTTP