### PR TITLE
Change ports from HTTPS alt 8443 to HTTP alt 8080

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,4 +63,4 @@ RUN \
 COPY /root /
 
 # ports and volumes
-EXPOSE 8443
+EXPOSE 8080

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -63,4 +63,4 @@ RUN \
 COPY /root /
 
 # ports and volumes
-EXPOSE 8443
+EXPOSE 8080

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -63,4 +63,4 @@ RUN \
 COPY /root /
 
 # ports and volumes
-EXPOSE 8443
+EXPOSE 8080

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ pipeline {
     MULTIARCH='true'
     CI='true'
     CI_WEB='true'
-    CI_PORT='8443'
+    CI_PORT='8080'
     CI_SSL='false'
     CI_DELAY='120'
     CI_DOCKERENV='TZ=US/Pacific'

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Container images are configured using parameters passed at runtime (such as thos
 
 | Parameter | Function |
 | :----: | --- |
-| `-p 8443` | web gui |
+| `-p 8080` | web gui |
 | `-e PUID=1000` | for UserID - see below for explanation |
 | `-e PGID=1000` | for GroupID - see below for explanation |
 | `-e TZ=Europe/London` | Specify a timezone to use EG Europe/London |
@@ -164,7 +164,7 @@ In this instance `PUID=1000` and `PGID=1000`, to find yours use `id user` as bel
 &nbsp;
 ## Application Setup
 
-Access the webui at `http://<your-ip>:8443`.  
+Access the webui at `http://<your-ip>:8080`.  
 For github integration, drop your ssh key in to `/config/.ssh`.  
 Then open a terminal from the top menu and set your github username and email via the following commands  
 ```

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ docker create \
   -e PASSWORD=password `#optional` \
   -e SUDO_PASSWORD=password `#optional` \
   -e PROXY_DOMAIN=code-server.my.domain `#optional` \
-  -p 8443:8443 \
+  -p 8080:8080 \
   -v /path/to/appdata/config:/config \
   --restart unless-stopped \
   linuxserver/code-server
@@ -111,7 +111,7 @@ services:
     volumes:
       - /path/to/appdata/config:/config
     ports:
-      - 8443:8443
+      - 8080:8080
     restart: unless-stopped
 ```
 

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -21,7 +21,7 @@ repo_vars:
   - MULTIARCH='true'
   - CI='true'
   - CI_WEB='true'
-  - CI_PORT='8443'
+  - CI_PORT='8080'
   - CI_SSL='false'
   - CI_DELAY='120'
   - CI_DOCKERENV='TZ=US/Pacific'

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -57,7 +57,7 @@ optional_block_1_items: ""
 # application setup block
 app_setup_block_enabled: true
 app_setup_block: |
-  Access the webui at `http://<your-ip>:8443`.  
+  Access the webui at `http://<your-ip>:8080`.  
   For github integration, drop your ssh key in to `/config/.ssh`.  
   Then open a terminal from the top menu and set your github username and email via the following commands  
   ```

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -39,7 +39,7 @@ param_volumes:
   - { vol_path: "/config", vol_host_path: "/path/to/appdata/config", desc: "Contains all relevant configuration files." }
 param_usage_include_ports: true
 param_ports:
-  - { external_port: "8443", internal_port: "8443", port_desc: "web gui" }
+  - { external_port: "8080", internal_port: "8080", port_desc: "web gui" }
 param_usage_include_env: true
 param_env_vars:
   - { env_var: "TZ", env_value: "Europe/London", desc: "Specify a timezone to use EG Europe/London"}

--- a/root/etc/services.d/code-server/run
+++ b/root/etc/services.d/code-server/run
@@ -16,7 +16,7 @@ fi
 exec \
 	s6-setuidgid abc \
 		/usr/local/bin/code-server \
-			--bind-addr 0.0.0.0:8443 \
+			--bind-addr 0.0.0.0:8080 \
 			--user-data-dir /config/data \
 			--extensions-dir /config/extensions \
 			--disable-telemetry \


### PR DESCRIPTION
We welcome all PR’s though this doesn’t guarantee it will be accepted.

## Description:
Change port 8443 to 8080 following HTTP/HTTPS best practices. 
Closes https://github.com/linuxserver/docker-code-server/issues/36

## Benefits of this PR and context:
Using HTTP on the HTTPS protocol causes issues on some proxy services and other firewalls. 

## Source / References:
[https://www.speedguide.net/port.php?port=8443](https://www.speedguide.net/port.php?port=8443)
[https://www.speedguide.net/port.php?port=8080](https://www.speedguide.net/port.php?port=8080)