### PR TITLE
fix apply chown permissions in parallel for large workspace

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -375,7 +375,9 @@ pipeline {
     // Build Docker container for push to LS Repo
     stage('Build-Single') {
       when {
-        environment name: 'MULTIARCH', value: 'false'
+        expression {
+          env.MULTIARCH == 'false' || params.PACKAGE_CHECK == 'true' 
+        }
         environment name: 'EXIT_STATUS', value: ''
       }
       steps {
@@ -400,7 +402,10 @@ pipeline {
     // Build MultiArch Docker containers for push to LS Repo
     stage('Build-Multi') {
       when {
-        environment name: 'MULTIARCH', value: 'true'
+        allOf {
+          environment name: 'MULTIARCH', value: 'true'
+          expression { params.PACKAGE_CHECK == 'false' }
+        }
         environment name: 'EXIT_STATUS', value: ''
       }
       parallel {
@@ -505,7 +510,7 @@ pipeline {
         sh '''#! /bin/bash
               set -e
               TEMPDIR=$(mktemp -d)
-              if [ "${MULTIARCH}" == "true" ]; then
+              if [ "${MULTIARCH}" == "true" ] && [ "${PACKAGE_CHECK}" == "false" ]; then
                 LOCAL_CONTAINER=${IMAGE}:amd64-${META_TAG}
               else
                 LOCAL_CONTAINER=${IMAGE}:${META_TAG}
@@ -566,7 +571,7 @@ pipeline {
       steps {
         sh '''#! /bin/bash
               echo "Packages were updated. Cleaning up the image and exiting."
-              if [ "${MULTIARCH}" == "true" ]; then
+              if [ "${MULTIARCH}" == "true" ] && [ "${PACKAGE_CHECK}" == "false" ]; then
                 docker rmi ${IMAGE}:amd64-${META_TAG}
               else
                 docker rmi ${IMAGE}:${META_TAG}
@@ -590,7 +595,7 @@ pipeline {
       steps {
         sh '''#! /bin/bash
               echo "There are no package updates. Cleaning up the image and exiting."
-              if [ "${MULTIARCH}" == "true" ]; then
+              if [ "${MULTIARCH}" == "true" ] && [ "${PACKAGE_CHECK}" == "false" ]; then
                 docker rmi ${IMAGE}:amd64-${META_TAG}
               else
                 docker rmi ${IMAGE}:${META_TAG}

--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **16.09.21:** - Fix slow `chown` on large workspace (contents of workspace folder no longer chowned).
 * **11.07.21:** - Bump node to 14 to fix builds
 * **08.05.21:** - Fix doc link
 * **04.02.20:** - Allow setting gui password via hash using env var `HASHED_PASSWORD`.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -75,8 +75,8 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "16.09.21:", desc: "Fix slow `chown` on large workspace (contents of workspace folder no longer chowned)." }
   - { date: "11.07.21:", desc: "Bump node to 14 to fix builds" }
-  - { date: "05.07.21:", desc: "Fix slow `chown` on large workspace" }
   - { date: "08.05.21:", desc: "Fix doc link" }
   - { date: "04.02.20:", desc: "Allow setting gui password via hash using env var `HASHED_PASSWORD`." }
   - { date: "23.12.20:", desc: "Allow setting sudo password via hash using env var `SUDO_PASSWORD_HASH`." }

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -76,6 +76,7 @@ app_setup_block: |
 # changelog
 changelogs:
   - { date: "11.07.21:", desc: "Bump node to 14 to fix builds" }
+  - { date: "05.07.21:", desc: "Fix slow `chown` on large workspace" }
   - { date: "08.05.21:", desc: "Fix doc link" }
   - { date: "04.02.20:", desc: "Allow setting gui password via hash using env var `HASHED_PASSWORD`." }
   - { date: "23.12.20:", desc: "Allow setting sudo password via hash using env var `SUDO_PASSWORD_HASH`." }

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -23,13 +23,13 @@ if [ -f "/usr/bin/find" ] && [ -f "/usr/bin/xargs" ]; then
     echo "setting permissions::configuration"
     CORES=$(nproc --all)
     find /config -maxdepth 4 -mindepth 1 -path /config/workspace -prune -false -o -type d -print0 | \
-        xargs --max-args=1 --max-procs=$((CORES*2*8)) \
+        xargs -r --max-args=1 --max-procs=$((CORES*2*8)) \
         chown -R abc:abc
 
     echo "setting permissions::workspace"
     chown abc:abc /config/workspace
     find /config/workspace -maxdepth 4 -mindepth 1 -type d -print0 | \
-        xargs --max-args=1 --max-procs=$((CORES*2*16)) \
+        xargs -r --max-args=1 --max-procs=$((CORES*2*16)) \
         chown -R abc:abc
 else
     chown -R abc:abc \

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -22,14 +22,14 @@ if [ -f "/usr/bin/find" ] && [ -f "/usr/bin/xargs" ]; then
     # Split workload between config and workspace
     echo "setting permissions::configuration"
     CORES=$(nproc --all)
-    find /config -maxdepth 4 -mindepth 1 -path /config/workspace -prune -false -o -type d | \
-        xargs --max-args=1 --max-procs=$(($CORES*2*8)) \
+    find /config -maxdepth 4 -mindepth 1 -path /config/workspace -prune -false -o -type d -print0 | \
+        xargs --max-args=1 --max-procs=$((CORES*2*8)) \
         chown -R abc:abc
 
     echo "setting permissions::workspace"
     chown abc:abc /config/workspace
-    find /config/workspace -maxdepth 4 -mindepth 1 -type d | \
-        xargs --max-args=1 --max-procs=$(($CORES*2*16)) \
+    find /config/workspace -maxdepth 4 -mindepth 1 -type d -print0 | \
+        xargs --max-args=1 --max-procs=$((CORES*2*16)) \
         chown -R abc:abc
 else
     chown -R abc:abc \

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -19,19 +19,19 @@ fi
 
 # permissions
 if [ -f "/usr/bin/find" ] && [ -f "/usr/bin/xargs" ]; then
+    CORES=$(nproc --all)
+
     # Split workload between config and workspace
     echo "setting permissions::configuration"
-    CORES=$(nproc --all)
-    find /config -maxdepth 4 -mindepth 1 -path /config/workspace -prune -false -o -type d -print0 | \
-        xargs -r --max-args=1 --max-procs=$((CORES*2*8)) \
+    find /config -path /config/workspace -prune -false -o -type d -print0 | \
+        xargs --null -r --max-args=1 --max-procs=$((CORES*2*8)) \
         chown -R abc:abc
 
     echo "setting permissions::workspace"
     chown abc:abc /config/workspace
-    find /config/workspace -maxdepth 4 -mindepth 1 -type d -print0 | \
-        xargs -r --max-args=1 --max-procs=$((CORES*2*16)) \
-        chown -R abc:abc
 else
-    chown -R abc:abc \
-        /config
+    # Set permissions on data mount
+    # do not decend into the workspace
+    chown -R abc:abc "$(ls /config -I workspace)"
+    chown abc:abc /config/workspace
 fi

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -18,5 +18,20 @@ if [ -n "${SUDO_PASSWORD}" ] || [ -n "${SUDO_PASSWORD_HASH}" ]; then
 fi
 
 # permissions
-chown -R abc:abc \
-    /config
+if [ -f "/usr/bin/find" ] && [ -f "/usr/bin/xargs" ]; then
+    # Split workload between config and workspace
+    echo "setting permissions::configuration"
+    CORES=$(nproc --all)
+    find /config -maxdepth 4 -mindepth 1 -path /config/workspace -prune -false -o -type d | \
+        xargs --max-args=1 --max-procs=$(($CORES*2*8)) \
+        chown -R abc:abc
+
+    echo "setting permissions::workspace"
+    chown abc:abc /config/workspace
+    find /config/workspace -maxdepth 4 -mindepth 1 -type d | \
+        xargs --max-args=1 --max-procs=$(($CORES*2*16)) \
+        chown -R abc:abc
+else
+    chown -R abc:abc \
+        /config
+fi


### PR DESCRIPTION
`chown` is always bound to a single core. See man page `chown`. Applying the permissions through a single process on a large workspace causes the container boot process to be slow. In order to mitigate slow container start times for large work spaces `chown` can be run in parallel. This PR provides that functionality.

## Gains
* Increase container boot time by a factor ~20
* Significant reduction in memory use on container start because the entire /config will not be loaded in a singular `chown` process which for a large config directory and/or workspace can easily increase to over 1.2 GB of additional memory.
* Automatic parallel process allocation based upon available cores

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-code-server/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:
Apply permissions through `chown` in parallel.

## Benefits of this PR and context:
Benefits are pure speed when it comes to starting the container.

The following test results are from a workspace with the following details.
```bash
Files: 134,834
Size: 9.8 GB
```

### Results before PR
```bash
real    17m27.335s
user    0m1.222s
sys     0m50.652s
```

### Results after PR
```bash
# chown /config
real    0m15.775s
user    0m0.809s
sys     0m12.201s

# chown /config/workspace
real    0m33.875s
user    0m2.461s
sys     0m42.309s
```


## How Has This Been Tested?
* Container build
* prefixed command with linux `time` command, recorded differences and attached them in this PR.
