### PR TITLE
Mention the need to escape dollar signs within HASHED_PASSWORD in docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ git config --global user.email "email address"
 
 How to create the [hashed password](https://github.com/cdr/code-server/blob/master/docs/FAQ.md#can-i-store-my-password-hashed).
 
+Note that when the hashed password is specified within `docker-compose`, all `$` characters in it should be escaped as `$$` to prevent `docker-compose` from interpreting them as variable notation. 
+
 ## Usage
 
 Here are some example snippets to help you get started creating a container.


### PR DESCRIPTION
That is not self-evident and mentioning it might save someone some frustration and debugging time.