### PR TITLE
Mention the need to escape dollar signs within HASHED_PASSWORD in docker-compose

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -74,6 +74,7 @@ app_setup_block: |
 
   How to create the [hashed password](https://github.com/cdr/code-server/blob/master/docs/FAQ.md#can-i-store-my-password-hashed).
 
+  Note that when the hashed password is specified within `docker-compose`, all `$` characters in it should be escaped as `$$` to prevent `docker-compose` from interpreting them as variable notation.
 
 # changelog
 changelogs:


### PR DESCRIPTION
That is not self-evident and mentioning it might save someone some frustration and debugging time.