### PR TITLE
Add git-lfs support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN \
   apt-get update && \
   apt-get install -y \
     git \
+    git-lfs \
     jq \
     libatomic1 \
     nano \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -16,6 +16,7 @@ RUN \
   apt-get update && \
   apt-get install -y \
     git \
+    git-lfs \
     jq \
     libatomic1 \
     nano \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -54,6 +54,7 @@ app_setup_block: |
   How to create the [hashed password](https://github.com/cdr/code-server/blob/master/docs/FAQ.md#can-i-store-my-password-hashed).
 # changelog
 changelogs:
+  - {date: "01.06.24:", desc: "Added the `git-lfs` package for [Git Large File Storage](https://git-lfs.com) support."}
   - {date: "01.07.23:", desc: "Deprecate armhf. As announced [here](https://www.linuxserver.io/blog/a-farewell-to-arm-hf)"}
   - {date: "05.10.22:", desc: "Install recommended deps to maintain parity with the older images."}
   - {date: "29.09.22:", desc: "Rebase to jammy, switch to s6v3. Fix chown logic to skip `/config/workspace` contents."}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [X] I have read the [contributing](https://github.com/linuxserver/docker-code-server/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------
## Description:

Adds the git-lfs apt package to enable support for [Git Large File Storage](https://git-lfs.com/).

## Benefits of this PR and context:

Git LFS is widely used for repos that contain binary files. As the Code-Server is often used with git, it makes for this small package to be included in order to have this functionality

My personal use case is using the `code-server` instance to edit the repo containing my [Obsidian](https://obsidian.md) notes vault, where LFS is used to store the attachments.

Even this repository is enabled for LFS as there is a `.gitattributes` file, so this use case is quite common, and IMHO it's worth including this in the base image as opposed to as an add-on via Docker Mods.

## How Has This Been Tested?
Tested that the package install from apt succeeded and git-lfs extensions were available.
Final testing will occur using LinuxServer CI.

## Source / References:

[Git Large File Storage](https://git-lfs.com/)
https://github.com/linuxserver/docker-code-server/blob/master/.gitattributes
