### PR TITLE
fix: use xargs to speed up chown during init

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-code-server/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-code-server/run
@@ -23,7 +23,7 @@ fi
     cp /root/.profile /config/.profile
 
 # fix permissions (ignore contents of /config/workspace)
-find /config -path /config/workspace -prune -o -exec chown abc:abc {} +
+find /config -path /config/workspace -prune -o -print0 | xargs -0 -n 1000 -P $(nproc) chown abc:abc
 chown abc:abc /config/workspace
 chmod 700 /config/.ssh
 if [ -n "$(ls -A /config/.ssh)" ]; then


### PR DESCRIPTION
`init-code-server` currently uses `find -exec` which accumulates all files before `chown`ing them.

This is slow for users with a lot of files. Using `xargs` makes it much faster.

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-code-server/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
- `find -print0` and `xargs -0` change everything to use null characters instead of whitespace between paths
- `-n 1000` is the number of files to `chown` per xarg execution
  - Performance capped once I got above ~20 and stayed there even up to 1 million, 1000 seemed a nice middle-ground between those which should maximize performance across different machine specs.
- `-P $(nproc)` set the parallelism to the number of cores

## Benefits of this PR and context:

### Old
```bash
$ time find /config -path /config/workspace -prune -o -exec chown abc:abc {} +

real    12m19.069s
user    0m1.601s
sys     2m33.088s
```

### New
```bash
$ time find /config -path /config/workspace -prune -o -print0 | xargs -0 -n 1000 -P $(nproc) chown abc:abc

real    0m46.416s
user    0m2.339s
sys     2m13.735s
```

## How Has This Been Tested?
Manually by modifying the init script when building my image.

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
