### PR TITLE
listen on both ipv4 and ipv6 even when running container as root

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **17.05.26:** - Let server listen on both ipv4 and ipv6 even when running container as root.
 * **10.08.25:** - Let server listen on both ipv4 and ipv6.
 * **03.06.25:** - Allow setting PWA name using env var `PWA_APPNAME`.
 * **13.10.24:** - Only chown config folder when change to ownership or new install is detected.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -102,6 +102,7 @@ init_diagram: |
   "code-server:latest" <- Base Images
 # changelog
 changelogs:
+  - {date: "17.05.26:", desc: "Let server listen on both ipv4 and ipv6 even when running container as root."}
   - {date: "10.08.25:", desc: "Let server listen on both ipv4 and ipv6."}
   - {date: "03.06.25:", desc: "Allow setting PWA name using env var `PWA_APPNAME`."}
   - {date: "13.10.24:", desc: "Only chown config folder when change to ownership or new install is detected."}

--- a/root/etc/s6-overlay/s6-rc.d/svc-code-server/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-code-server/run
@@ -23,7 +23,7 @@ if [[ -z ${LSIO_NON_ROOT_USER} ]]; then
         s6-notifyoncheck -d -n 300 -w 1000 -c "nc -z 127.0.0.1 8443" \
             s6-setuidgid abc \
                 /app/code-server/bin/code-server \
-                    --bind-addr 0.0.0.0:8443 \
+                    --bind-addr "[::]:8443" \
                     --user-data-dir /config/data \
                     --extensions-dir /config/extensions \
                     --disable-telemetry \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [X] I have read the [contributing](https://github.com/linuxserver/docker-code-server/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
Updated `/root/etc/s6-overlay/s6-rc.d/svc-code-server/run` to change `--bind-addr` from `0.0.0.0:8443` to `[::]:8443` when the container is executed as the root user. 
Also added the corresponding changelog entry in `readme-vars.yml` (and `README.md`).

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
In a #179, the container was configured to listen on both IPv4 and IPv6. However, that change seems to have been missed or not fully applied for the root execution path. This PR corrects it so that `code-server` properly binds to `[::]:8443` regardless of whether it's running as root or a non-root user.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- OS: Arch Linux (Kernel 7.0.8-zen1-1-zen)
- Docker: 29.5.0
- Docker Compose: 5.1.3

### Test A: dual stack

compose.yaml
```yaml
services:
  vscode:
    image: linuxserver/code-server:latest
    environment:
      - PUID=1000
      - PGID=1000
      - PASSWORD=[redacted]
      - SUDO_PASSWORD=[redacted]
    volumes:
      - ./data:/config/workspace
      - ./code-config:/config
    ports:
      - "8443:8443"
    restart: unless-stopped

networks:
  default:
    enable_ipv6: true
```

- before: Accessing `localhost:8443` resulted in a `CONNECTION_RESET` error.
- after:  Accessing `localhost:8443` connects successfully.

### Test B: IPv4 only

compose.yaml
```yaml
services:
  vscode:
    image: linuxserver/code-server:latest
    environment:
      - PUID=1000
      - PGID=1000
      - PASSWORD=[redacted]
      - SUDO_PASSWORD=[redacted]
    volumes:
      - ./data:/config/workspace
      - ./code-config:/config
    ports:
      - "8443:8443"
    restart: unless-stopped
```

- before and after: Accessing `localhost:8443` connects successfully.

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->

#179
