### PR TITLE
Fix/bind addr ipv6 fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **06.07.26:** - Fall back to ipv4 bind address when ipv6 is disabled in the kernel.
 * **17.05.26:** - Let server listen on both ipv4 and ipv6 even when running container as root.
 * **10.08.25:** - Let server listen on both ipv4 and ipv6.
 * **03.06.25:** - Allow setting PWA name using env var `PWA_APPNAME`.

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ services:
       - PROXY_DOMAIN=code-server.my.domain #optional
       - DEFAULT_WORKSPACE=/config/workspace #optional
       - PWA_APPNAME=code-server #optional
+      - BIND_ADDR="[::]:8443" #optional
     volumes:
       - /path/to/code-server/config:/config
     ports:
@@ -140,6 +141,7 @@ docker run -d \
   -e PROXY_DOMAIN=code-server.my.domain `#optional` \
   -e DEFAULT_WORKSPACE=/config/workspace `#optional` \
   -e PWA_APPNAME=code-server `#optional` \
+  -e BIND_ADDR="[::]:8443" #optional
   -p 8443:8443 \
   -v /path/to/code-server/config:/config \
   --restart unless-stopped \
@@ -163,6 +165,7 @@ Containers are configured using parameters passed at runtime (such as those abov
 | `-e PROXY_DOMAIN=code-server.my.domain` | If this optional variable is set, this domain will be proxied for subdomain proxying. See [Documentation](https://github.com/coder/code-server/blob/main/docs/guide.md#using-a-subdomain) |
 | `-e DEFAULT_WORKSPACE=/config/workspace` | If this optional variable is set, code-server will open this directory by default |
 | `-e PWA_APPNAME=code-server` | If this optional variable is set, the PWA app will the specified name. |
+| `-e BIND_ADDR=[::]:8443` | If this optional variable is set, code-server will listen to this address instead of auto-detecting. |
 | `-v /config` | Contains all relevant configuration files. |
 | `--read-only=true` | Run container with a read-only filesystem. Please [read the docs](https://docs.linuxserver.io/misc/read-only/). |
 | `--user=1000:1000` | Run container with a non-root user. Please [read the docs](https://docs.linuxserver.io/misc/non-root/). |

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -102,6 +102,7 @@ init_diagram: |
   "code-server:latest" <- Base Images
 # changelog
 changelogs:
+  - {date: "06.07.26:", desc: "Fall back to ipv4 bind address when ipv6 is disabled in the kernel."}
   - {date: "17.05.26:", desc: "Let server listen on both ipv4 and ipv6 even when running container as root."}
   - {date: "10.08.25:", desc: "Let server listen on both ipv4 and ipv6."}
   - {date: "03.06.25:", desc: "Allow setting PWA name using env var `PWA_APPNAME`."}

--- a/root/etc/s6-overlay/s6-rc.d/svc-code-server/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-code-server/run
@@ -18,12 +18,21 @@ if [[ -z ${PWA_APPNAME} ]]; then
     PWA_APPNAME="code-server"
 fi
 
+# Bind to the IPv6 wildcard (dual-stack, also serves IPv4) when IPv6 is
+# available, otherwise fall back to the IPv4 wildcard. Binding to "[::]"
+# fails outright on hosts/containers where IPv6 is disabled.
+if [[ -e /proc/net/if_inet6 ]]; then
+    BIND_ADDR="[::]:8443"
+else
+    BIND_ADDR="0.0.0.0:8443"
+fi
+
 if [[ -z ${LSIO_NON_ROOT_USER} ]]; then
     exec \
         s6-notifyoncheck -d -n 300 -w 1000 -c "nc -z 127.0.0.1 8443" \
             s6-setuidgid abc \
                 /app/code-server/bin/code-server \
-                    --bind-addr "[::]:8443" \
+                    --bind-addr "${BIND_ADDR}" \
                     --user-data-dir /config/data \
                     --extensions-dir /config/extensions \
                     --disable-telemetry \

--- a/root/etc/s6-overlay/s6-rc.d/svc-code-server/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-code-server/run
@@ -18,13 +18,15 @@ if [[ -z ${PWA_APPNAME} ]]; then
     PWA_APPNAME="code-server"
 fi
 
-# Bind to the IPv6 wildcard (dual-stack, also serves IPv4) when IPv6 is
-# available, otherwise fall back to the IPv4 wildcard. Binding to "[::]"
-# fails outright on hosts/containers where IPv6 is disabled.
-if [[ -e /proc/net/if_inet6 ]]; then
-    BIND_ADDR="[::]:8443"
-else
-    BIND_ADDR="0.0.0.0:8443"
+if [[ -z ${BIND_ADDR} ]] ; then
+    # Bind to the IPv6 wildcard (dual-stack, also serves IPv4) when IPv6 is
+    # available, otherwise fall back to the IPv4 wildcard. Binding to "[::]"
+    # fails outright on hosts/containers where IPv6 is disabled.
+    if [[ -e /proc/net/if_inet6 ]]; then
+        BIND_ADDR="[::]:8443"
+    else
+        BIND_ADDR="0.0.0.0:8443"
+    fi
 fi
 
 if [[ -z ${LSIO_NON_ROOT_USER} ]]; then


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-code-server/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:

Commit 84a119f (#216) switched `--bind-addr` to `"[::]:8443"` so the service listens on both IPv4 and IPv6 via dual-stack. This works fine when an IPv6 stack is present (even on IPv4-only networks), but it fails outright when IPv6 is disabled at the kernel level (e.g. `ipv6.disable=1`, kernel built without `CONFIG_IPV6`, or the module not loaded). In that case there is no `AF_INET6` socket family, so binding to `[::]` fails with `EAFNOSUPPORT` and code-server never starts — the container becomes unreachable.

This PR detects IPv6 availability at startup via the presence of `/proc/net/if_inet6` (the standard indicator that the kernel has IPv6 support) and chooses the bind address accordingly:

- IPv6 available  → `[::]:8443` (dual-stack, unchanged behaviour from #216)
- IPv6 unavailable → `0.0.0.0:8443` (IPv4 fallback)

Both the root and non-root exec paths use the shared `BIND_ADDR` variable.

## Benefits of this PR and context:

Restores the ability to run the container on hosts/kernels with IPv6 disabled, which regressed after #216, while fully preserving the dual-stack behaviour that #216 introduced for everyone else. No configuration or environment variables are required — the correct address is selected automatically.

## How Has This Been Tested?

Verified in a container inheriting a host kernel with IPv6 fully disabled
(`/proc/net/if_inet6` and `/proc/sys/net/ipv6` absent):

- Binding to `[::]:8443` fails with `[Errno 97] Address family not supported by protocol` (reproduces the regression).
- Binding to `0.0.0.0:8443` succeeds.
- `[[ -e /proc/net/if_inet6 ]]` correctly evaluates false, so the script selects   the `0.0.0.0` fallback.

On a normal dual-stack host `/proc/net/if_inet6` is present and the script keeps `[::]:8443`, so existing IPv4+IPv6 behaviour is unchanged.

## Source / References:

- Regressing change: #216 (`--bind-addr "[::]:8443"`)
- Related IPv4-only test note in #216 did not cover kernels with IPv6 *disabled*
  (only IPv6-less networks with the stack still present).
- Prior art for the same class of problem in the LSIO ecosystem:
  linuxserver/docker-swag#92

Closes #218